### PR TITLE
Budfix TextImgProvider.py

### DIFF
--- a/service/provider/TextImgProvider.py
+++ b/service/provider/TextImgProvider.py
@@ -170,9 +170,9 @@ class TextImgProvider(NextBlockGenerator):
         fp = self.next_font_path()
 
         if isinstance(strategy, HorizontalStrategy):
-            orientation = TYPE_ORIENTATION_VERTICAL
-        elif isinstance(strategy, VerticalStrategy):
             orientation = TYPE_ORIENTATION_HORIZONTAL
+        elif isinstance(strategy, VerticalStrategy):
+            orientation = TYPE_ORIENTATION_VERTICAL
         elif isinstance(strategy, HorizontalFlowStrategy):
             orientation = TYPE_ORIENTATION_HORIZONTAL
         elif isinstance(strategy, VerticalFlowStrategy):


### PR DESCRIPTION
当 strategy 是 "HorizontalStrategy"时，变量orientation 是否应该赋值成 TYPE_ORIENTATION_HORIZONTAL才对呢？